### PR TITLE
Support MariaDB on Debian Stretch

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,7 +125,7 @@ mysql_users: []
 # MariaDB
 # -------------------------------------
 mysql_mariadb_version: '10.1'
-# See: http://mariadb.org/mariadb/repositories/
+# See: https://downloads.mariadb.org/mariadb/repositories
 mysql_mariadb_repository: "http://ftp.igh.cnrs.fr/pub/mariadb/repo/{{ mysql_mariadb_version }}/debian"
 
 # -------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ mysql_query_cache_size: '16M'
 mysql_wait_timeout: 28800
 
 # Try number of CPU's * 2 for thread_concurrency.
-mysql_thread_concurrency: 2
+mysql_thread_concurrency: "{{ ansible_processor_cores * 2 }}"
 
 # InnoDB settings.
 mysql_innodb_file_per_table: '1'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ mysql_thread_concurrency: 2
 mysql_innodb_file_per_table: '1'
 mysql_innodb_buffer_pool_size: "{{ (ansible_memtotal_mb * 0.2) | round | int }}M"
 mysql_innodb_additional_mem_pool_size: '20M' # See: http://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_additional_mem_pool_size
-mysql_innodb_log_file_size: '64M'
+mysql_innodb_log_file_size: '64M' # If this setting changes on a running system, you will break it! http://dev.mysql.com/doc/refman/5.6/en/innodb-data-log-reconfiguration.html
 mysql_innodb_log_buffer_size: '8M'
 mysql_innodb_flush_log_at_trx_commit: '1'
 mysql_innodb_lock_wait_timeout: 50

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,7 +137,9 @@ mysql_percona_version: '5.6'
 mysql_percona_repository: 'http://repo.percona.com/apt'
 mysql_use_percona_apt: false
 
+# -------------------------------------
 # Galera
+# -------------------------------------
 mysql_galera_resetup: false
 mysql_galera_members: []
 mysql_galera_primary_node: 'change_me' # See: https://github.com/ansible/ansible/issues/17453

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -143,3 +143,13 @@ mysql_use_percona_apt: false
 mysql_galera_resetup: false
 mysql_galera_members: []
 mysql_galera_primary_node: 'change_me' # See: https://github.com/ansible/ansible/issues/17453
+
+# -------------------------------------
+# Tools
+# -------------------------------------
+mysql_tools:
+  - mytop              # Not available on Debian Stretch (included in mariadb-client instead)
+  - percona-toolkit
+  - percona-xtrabackup # Not available on Debian Stretch (without using the Percona repository)
+  - python-mysqldb
+  - mysqltuner

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,9 @@ mysql_upstream_apt_src: false
 # Configuration
 # -------------------------------------
 
+# MySQL configuration template
+mysql_config_template: 'etc/mysql/my.cnf.j2'
+
 # MySQL connection settings.
 mysql_port: "3306"
 mysql_bind_address: '127.0.0.1'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -127,6 +127,8 @@ mysql_users: []
 mysql_mariadb_version: '10.1'
 # See: https://downloads.mariadb.org/mariadb/repositories
 mysql_mariadb_repository: "http://ftp.igh.cnrs.fr/pub/mariadb/repo/{{ mysql_mariadb_version }}/debian"
+mysql_mariadb_key_server: "keyserver.ubuntu.com"
+mysql_mariadb_key_id: '0xcbcb082a1bb943db'
 
 # -------------------------------------
 # Percona

--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -35,9 +35,4 @@
 
 - name: APT | Install few MySQL related tools
   apt: pkg={{ item }} state=present install_recommends=no
-  with_items:
-    - mytop
-    - percona-toolkit
-    - percona-xtrabackup
-    - python-mysqldb
-    - mysqltuner
+  with_items: "{{ mysql_tools }}"

--- a/tasks/install/mariadb/upstream.yml
+++ b/tasks/install/mariadb/upstream.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: APT | Install MariaDB key
-  apt_key: keyserver="keyserver.ubuntu.com" id="0xcbcb082a1bb943db" state=present
+  apt_key: keyserver="{{ mysql_mariadb_key_server }}" id="{{ mysql_mariadb_key_id }}" state=present
 
 - name: APT | Add MariaDB repository
   apt_repository: repo='deb {{ mysql_mariadb_repository }} {{ ansible_distribution_release }} main' state=present
@@ -12,4 +12,3 @@
 
 - name: INCLUDE | Normal Install
   include: default.yml
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   include: install/main.yml
 
 - name: TEMPLATE | Deploy configuration
-  template: src=etc/mysql/my.cnf.j2 dest=/etc/mysql/my.cnf
+  template: "src={{ mysql_config_template }} dest=/etc/mysql/my.cnf"
   register: config
 
 - name: TEMPLATE | Deploy extra configuration

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -66,12 +66,14 @@ innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}
 {% if mysql_vendor != 'mariadb' or mysql_mariadb_version | version_compare('10.0', '<') %}
 innodb_additional_mem_pool_size = {{ mysql_innodb_additional_mem_pool_size }}
 {% endif %}
-#innodb_log_file_size = {{ mysql_innodb_log_file_size }}
-#innodb_log_buffer_size = {{ mysql_innodb_log_buffer_size }}
-
-{# It craches after install (mysql 5.5)... TODO FIX -> http://dev.mysql.com/doc/refman/5.6/en/innodb-data-log-reconfiguration.html #}
+innodb_log_buffer_size = {{ mysql_innodb_log_buffer_size }}
 innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
 innodb_lock_wait_timeout = {{ mysql_innodb_lock_wait_timeout }}
+
+{# If this setting changes on a running system, you will break it! #}
+{# See how tho change it here: http://dev.mysql.com/doc/refman/5.6/en/innodb-data-log-reconfiguration.html #}
+{# TODO FIX -> Maybe detect a change and fail, just to be safe? #}
+innodb_log_file_size = {{ mysql_innodb_log_file_size }}
 
 [mysqldump]
 quick

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -14,15 +14,15 @@ socket = {{ mysql_socket }}
 
 {# TODO: FIX later #}
 # Logging configuration.
-#{% if mysql_log_error == 'syslog' or mysql_log == 'syslog' %}
-#syslog
-#syslog-tag = {{ mysql_syslog_tag }}
-#{% else %}
-#{% if mysql_log %}
-#log = {{ mysql_log }}
-#{% endif %}
-#log-error = {{ mysql_log_error }}
-#{% endif %}
+{% if mysql_log_error == 'syslog' or mysql_log == 'syslog' %}
+syslog
+syslog-tag = {{ mysql_syslog_tag }}
+{% else %}
+{% if mysql_log %}
+log = {{ mysql_log }}
+{% endif %}
+log-error = {{ mysql_log_error }}
+{% endif %}
 
 {% if mysql_slow_query_log_enabled %}
 # Slow query log configuration.

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -12,7 +12,7 @@ bind-address = {{ mysql_bind_address }}
 datadir = {{ mysql_datadir }}
 socket = {{ mysql_socket }}
 
-# TODO: FIX later
+{# TODO: FIX later #}
 # Logging configuration.
 #{% if mysql_log_error == 'syslog' or mysql_log == 'syslog' %}
 #syslog
@@ -31,8 +31,6 @@ slow_query_log = 1
 slow_query_log_file = {{ mysql_slow_query_log_file }}
 long_query_time = {{ mysql_slow_query_time }}
 {% endif %}
-
-
 
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links = 0
@@ -66,9 +64,10 @@ innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}
 {% if mysql_innodb_additional_mem_pool_size is defined %}
 innodb_additional_mem_pool_size = {{ mysql_innodb_additional_mem_pool_size }}
 {% endif %}
-# It craches after install (mysql 5.5)... TODO FIX -> http://dev.mysql.com/doc/refman/5.6/en/innodb-data-log-reconfiguration.html
 #innodb_log_file_size = {{ mysql_innodb_log_file_size }}
 #innodb_log_buffer_size = {{ mysql_innodb_log_buffer_size }}
+
+{# It craches after install (mysql 5.5)... TODO FIX -> http://dev.mysql.com/doc/refman/5.6/en/innodb-data-log-reconfiguration.html #}
 innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
 innodb_lock_wait_timeout = {{ mysql_innodb_lock_wait_timeout }}
 

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -26,7 +26,9 @@ log-error = {{ mysql_log_error }}
 
 {% if mysql_slow_query_log_enabled %}
 # Slow query log configuration.
+{% if mysql_vendor != 'mariadb' or mysql_mariadb_version | version_compare('10.0', '<') %}
 log_slow_queries = 1
+{% endif %}
 slow_query_log = 1
 slow_query_log_file = {{ mysql_slow_query_log_file }}
 long_query_time = {{ mysql_slow_query_time }}
@@ -61,7 +63,7 @@ thread_concurrency = {{ mysql_thread_concurrency }}
 # InnoDB settings.
 innodb_file_per_table = {{ mysql_innodb_file_per_table }}
 innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}
-{% if mysql_innodb_additional_mem_pool_size is defined %}
+{% if mysql_vendor != 'mariadb' or mysql_mariadb_version | version_compare('10.0', '<') %}
 innodb_additional_mem_pool_size = {{ mysql_innodb_additional_mem_pool_size }}
 {% endif %}
 #innodb_log_file_size = {{ mysql_innodb_log_file_size }}


### PR DESCRIPTION
This PR contains some general improvements and fixes in order to install MariaDB (upstream) on Debian (9) Stretch. The commit messages should speak for themselves.

If you have questions, please ask!