### PR TITLE
Replace deprecated "include" with "include_tasks"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 env:
-  - PLATFORM='docker-jessie-default-mysql-master'      ANSIBLE_VERSION='ansible>=2.3,<2.4'
-  - PLATFORM='docker-jessie-default-mariadb-master'    ANSIBLE_VERSION='ansible>=2.3,<2.4'
-  - PLATFORM='docker-jessie-upstream-mariadb-master'   ANSIBLE_VERSION='ansible>=2.3,<2.4'
-  - PLATFORM='docker-jessie-upstream-percona-master'   ANSIBLE_VERSION='ansible>=2.3,<2.4'
-  - PLATFORM='docker-jessie-upstream-mariadbgalera-1'  ANSIBLE_VERSION='ansible>=2.3,<2.4'
-  - PLATFORM='docker-stretch-default-mysql-master'     ANSIBLE_VERSION='ansible>=2.3,<2.4'
-  - PLATFORM='docker-stretch-default-mariadb-master'   ANSIBLE_VERSION='ansible>=2.3,<2.4'
-  - PLATFORM='docker-stretch-upstream-mariadb-master'  ANSIBLE_VERSION='ansible>=2.3,<2.4'
-  - PLATFORM='docker-stretch-upstream-mariadbgalera-1' ANSIBLE_VERSION='ansible>=2.3,<2.4'
+  - PLATFORM='docker-jessie-default-mysql-master'      ANSIBLE_VERSION='ansible>=2.4'
+  - PLATFORM='docker-jessie-default-mariadb-master'    ANSIBLE_VERSION='ansible>=2.4'
+  - PLATFORM='docker-jessie-upstream-mariadb-master'   ANSIBLE_VERSION='ansible>=2.4'
+  - PLATFORM='docker-jessie-upstream-percona-master'   ANSIBLE_VERSION='ansible>=2.4'
+  - PLATFORM='docker-jessie-upstream-mariadbgalera-1'  ANSIBLE_VERSION='ansible>=2.4'
+  - PLATFORM='docker-stretch-default-mysql-master'     ANSIBLE_VERSION='ansible>=2.4'
+  - PLATFORM='docker-stretch-default-mariadb-master'   ANSIBLE_VERSION='ansible>=2.4'
+  - PLATFORM='docker-stretch-upstream-mariadb-master'  ANSIBLE_VERSION='ansible>=2.4'
+  - PLATFORM='docker-stretch-upstream-mariadbgalera-1' ANSIBLE_VERSION='ansible>=2.4'
 
 matrix:
   allow_failures:
-    - env: PLATFORM='docker-stretch-upstream-mariadb-master'  ANSIBLE_VERSION='ansible>=2.3,<2.4'
-    - env: PLATFORM='docker-stretch-upstream-mariadbgalera-1' ANSIBLE_VERSION='ansible>=2.3,<2.4'
+    - env: PLATFORM='docker-stretch-upstream-mariadb-master'  ANSIBLE_VERSION='ansible>=2.4'
+    - env: PLATFORM='docker-stretch-upstream-mariadbgalera-1' ANSIBLE_VERSION='ansible>=2.4'
   fast_finish: true
 
 sudo: required
@@ -27,7 +27,7 @@ services:
 before_install:
   - wget https://releases.hashicorp.com/vagrant/1.9.5/vagrant_1.9.5_x86_64.deb
   - sudo dpkg -i vagrant_1.9.5_x86_64.deb
-  - vagrant plugin install vagrant-hostmanager 
+  - vagrant plugin install vagrant-hostmanager
 
 install:
   - pip install "$ANSIBLE_VERSION"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,10 @@
 ---
 galaxy_info:
   author: Emilien Mantel
-  description: Install and configure MySQL or MariaDB (Galera Cluster) or Percona server on Debian 
-  company: 
+  description: Install and configure MySQL or MariaDB (Galera Cluster) or Percona server on Debian
+  company:
   license: GPLv2
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
   - name: Debian
     versions:
@@ -24,4 +24,4 @@ galaxy_info:
   - jessie
   - stretch
 dependencies: []
-  
+

--- a/tasks/galera/main.yml
+++ b/tasks/galera/main.yml
@@ -4,12 +4,12 @@
   template: src=etc/mysql/conf.d/09-galera.cnf.j2 dest=/etc/mysql/conf.d/09-galera.cnf
   register: galeraconfig
 
-- name: INCLUDE | Bootstrap first node
-  include: 'bootstrap.yml'
+- name: INCLUDE_TASKS | Bootstrap first node
+  include_tasks: bootstrap.yml
   when: inventory_hostname == mysql_galera_primary_node
 
-- name: INCLUDE | Configure other nodes
-  include: 'nodes.yml'
+- name: INCLUDE_TASKS | Configure other nodes
+  include_tasks: nodes.yml
   when: inventory_hostname != mysql_galera_primary_node
 
 - name: SERVICE | Restart MariaDB if needed

--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -11,26 +11,26 @@
     (mysql_origin ==  'upstream' and mysql_vendor == 'percona')
     )
 
-- name: INCLUDE | Use Percona repository
-  include: 'percona/apt.yml'
+- name: INCLUDE_TASKS | Use Percona repository
+  include_tasks: percona/apt.yml
   when: >
     mysql_use_percona_apt and
     not (mysql_origin ==  'upstream' and mysql_vendor == 'percona')
 
-- name: INCLUDE | Install MySQL from default repo
-  include: 'mysql/default.yml'
+- name: INCLUDE_TASKS | Install MySQL from default repo
+  include_tasks: mysql/default.yml
   when: mysql_origin == 'default' and mysql_vendor == 'mysql'
 
-- name: INCLUDE | Install MariaDB from Debian repo
-  include: 'mariadb/default.yml'
+- name: INCLUDE_TASKS | Install MariaDB from Debian repo
+  include_tasks: mariadb/default.yml
   when: mysql_origin == 'default' and mysql_vendor == 'mariadb'
 
-- name: INCLUDE | Install MariaDB from MariaDB repo
-  include: 'mariadb/upstream.yml'
+- name: INCLUDE_TASKS | Install MariaDB from MariaDB repo
+  include_tasks: mariadb/upstream.yml
   when: mysql_origin == 'upstream' and (mysql_vendor == 'mariadb' or mysql_vendor == 'mariadb_galera')
 
-- name: INCLUDE | Install Percona Server from Percona repo
-  include: 'percona/upstream.yml'
+- name: INCLUDE_TASKS | Install Percona Server from Percona repo
+  include_tasks: percona/upstream.yml
   when: mysql_origin ==  'upstream' and mysql_vendor == 'percona'
 
 - name: APT | Install few MySQL related tools

--- a/tasks/install/mariadb/upstream.yml
+++ b/tasks/install/mariadb/upstream.yml
@@ -14,5 +14,5 @@
   apt_repository: repo='deb-src {{ mysql_mariadb_repository }} {{ ansible_distribution_release }} main' state=present
   when: mysql_upstream_apt_src
 
-- name: INCLUDE | Normal Install
-  include: default.yml
+- name: INCLUDE_TASKS | Normal Install
+  include_tasks: default.yml

--- a/tasks/install/percona/upstream.yml
+++ b/tasks/install/percona/upstream.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: INCLUDE | Add percona APT repository
-  include: apt.yml
+- name: INCLUDE_TASKS | Add percona APT repository
+  include_tasks: apt.yml
 
 - name: DEBCONF | Prepare MySQL silent installation (root password)
   debconf: name='percona-server-server-{{ mysql_percona_version }}' question='percona-server-server/root_password' vtype='password' value='{{ mysql_root_password }}'
@@ -13,4 +13,3 @@
 
 - name: APT | Install Percona
   apt: update_cache=yes cache_valid_time=3600 pkg='percona-server-server-{{ mysql_percona_version }}' state=present
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,8 +8,8 @@
   register: mysql_exists
   changed_when: false
 
-- name: INCLUDE | Install
-  include: install/main.yml
+- name: INCLUDE_TASKS | Install
+  include_tasks: install/main.yml
 
 - name: TEMPLATE | Deploy configuration
   template: "src={{ mysql_config_template }} dest=/etc/mysql/my.cnf"
@@ -28,16 +28,16 @@
 - name: TEMPLATE Create .my.cnf for root
   template: src=root/my.cnf dest=/root/.my.cnf owner=root group=root mode=0600 backup=yes
 
-- name: INCLUDE | Galera
-  include: galera/main.yml
+- name: INCLUDE_TASKS | Galera
+  include_tasks: galera/main.yml
   when: mysql_vendor == 'mariadb_galera'
 
-- name: INCLUDE | Replication
-  include: replication/main.yml
+- name: INCLUDE_TASKS | Replication
+  include_tasks: replication/main.yml
   when: mysql_replication_master or mysql_replication_slave
 
-- name: INCLUDE | Secure install
-  include: 'secure.yml'
+- name: INCLUDE_TASKS | Secure install
+  include_tasks: secure.yml
 
 - name: SERVICE | Ensure service is started
   service: name=mysql state=started

--- a/tasks/replication/main.yml
+++ b/tasks/replication/main.yml
@@ -10,11 +10,11 @@
     ( mysql_vendor == 'mariadb' and vc.msg | version_compare('10.0.2', 'ge') ) or
     ( mysql_vendor in ['mysql', 'percona'] and vc.msg | version_compare('5.6.5', 'ge') )
 
-- name: INCLUDE | Replication Master
-  include: master.yml
+- name: INCLUDE_TASKS | Replication Master
+  include_tasks: master.yml
   when: mysql_replication_master
 
-- name: INCLUDE | Replication slave
-  include: slave.yml
+- name: INCLUDE_TASKS | Replication slave
+  include_tasks: slave.yml
   when: mysql_replication_slave
 

--- a/tasks/replication/slave.yml
+++ b/tasks/replication/slave.yml
@@ -15,20 +15,20 @@
   ignore_errors: yes
   register: slave_status
 
-- name: INCLUDE | Transfert /etc/mysql/debian.cnf from master
-  include: slave/ssh.yml
+- name: INCLUDE_TASKS | Transfert /etc/mysql/debian.cnf from master
+  include_tasks: slave/ssh.yml
   when: mysql_slave_replicate_mysqldb or ((slave_status.failed is defined or not slave_status.Is_Slave) and mysql_slave_import_data)
 
-- name: INCLUDE | Import data
-  include: slave/import_data.yml
+- name: INCLUDE_TASKS | Import data
+  include_tasks: slave/import_data.yml
   when: (slave_status.failed is defined or not slave_status.Is_Slave) and mysql_slave_import_data
 
-- name: INCLUDE | Configure replication
-  include: slave/replication.yml
+- name: INCLUDE_TASKS | Configure replication
+  include_tasks: slave/replication.yml
   when: (slave_status.failed is defined or not slave_status.Is_Slave) or mysql_slave_force_setup
 
-- name: INCLUDE | Transfert /etc/mysql/debian.cnf from master
-  include: slave/debiancnf.yml
+- name: INCLUDE_TASKS | Transfert /etc/mysql/debian.cnf from master
+  include_tasks: slave/debiancnf.yml
   when: mysql_slave_replicate_mysqldb
 
 - name: MYSQL_REPLICATION | Get slave status
@@ -36,8 +36,8 @@
   ignore_errors: yes
   register: slave_status
 
-- name: Configure MariaDB GTID
-  include: slave/mariadb_gtid.yml
+- name: INCLUDE_TASKS | Configure MariaDB GTID
+  include_tasks: slave/mariadb_gtid.yml
   when: >
     mysql_vendor == 'mariadb' and
     slave_status.Using_Gtid == 'No' and


### PR DESCRIPTION
Starting with Ansible 2.4, `include` has been deprecated. This PR replaces `include` with `include_tasks`, getting rid of an annoying deprecated notice.

You'll want to take care about versioning, when merging this PR, Ansible 2.3 and below are no longer supported.