### PR TITLE
Galera improvements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,9 +137,10 @@ mariadb_key_ids: ['0xcbcb082a1bb943db', '0xf1656f24c74cd1d8']
 mariadb_galera_resetup: false
 mariadb_galera_members: []
 mariadb_galera_primary_node: 'change_me' # See: https://github.com/ansible/ansible/issues/17453
+mariadb_wsrep_stt_method: 'rsync'
 
 # -------------------------------------
-# Percona 
+# Percona
 # -------------------------------------
 mariadb_percona_repository: 'http://repo.percona.com/apt'
 mariadb_use_percona_apt: false

--- a/templates/etc/mysql/conf.d/09-galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/09-galera.cnf.j2
@@ -29,4 +29,6 @@ binlog_format=ROW
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
 innodb_doublewrite=1
+{% if mariadb_version == '10.0'%}
 query_cache_size=0
+{% endif %}

--- a/templates/etc/mysql/conf.d/09-galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/09-galera.cnf.j2
@@ -14,7 +14,9 @@ wsrep_provider=/usr/lib/galera/libgalera_smm.so
 wsrep_cluster_address=gcomm://{{ mariadb_galera_members | join(",") }}
 # TODO: https://mariadb.com/kb/en/mariadb/galera-cluster-system-variables/#wsrep_sst_method
 wsrep_sst_method=rsync
-# TODO: wsrep_cluster_name="my_wsrep_cluster"
+{% if mariadb_wsrep_cluster_name is defined %}
+wsrep_cluster_name="{{ mariadb_wsrep_cluster_name }}"
+{% endif %}
 
 # Node Configuration
 wsrep_node_address="{{ mariadb_wsrep_node_address | default(ansible_default_ipv4.address) }}"

--- a/templates/etc/mysql/conf.d/09-galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/09-galera.cnf.j2
@@ -12,8 +12,7 @@
 wsrep_on=ON
 wsrep_provider=/usr/lib/galera/libgalera_smm.so
 wsrep_cluster_address=gcomm://{{ mariadb_galera_members | join(",") }}
-# TODO: https://mariadb.com/kb/en/mariadb/galera-cluster-system-variables/#wsrep_sst_method
-wsrep_sst_method=rsync
+wsrep_sst_method="{{ mariadb_wsrep_stt_method }}"
 {% if mariadb_wsrep_cluster_name is defined %}
 wsrep_cluster_name="{{ mariadb_wsrep_cluster_name }}"
 {% endif %}


### PR DESCRIPTION
Hi
I have made some additions in the playbook for galera cluster users.
Possibility to modify the cluster name
Possibility to change stt method
Possibility to have query cache (it is working since version > 10.0), it makes a big difference on server performance.

It is working in production for us.
It is not breaking change with existing playbooks : I have put default and is defined to be sure it won't change existing settings.

