### PR TITLE
create databases: use a list of database objects as per ansible mysql_db

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,8 +59,7 @@
 
 - name: MYSQL_DB | Create databases
   mysql_db:
-    name: "{{ item }}"
-    state: present
+    "{{item}}"
   with_items: "{{ mariadb_databases }}"
 
 - name: MYSQL_USER | Manages users...


### PR DESCRIPTION
this would enable defining a list of database object with parameters mapping the standard ansible mysql_db, and therefore also defining given databases should be 'present' or 'absent' 