### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -14,9 +14,8 @@
 
 - name: APT | Install few MariaDB related tools
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ mariadb_tools }}"
     install_recommends: no
-  with_items: "{{ mariadb_tools }}"
 
 - name: APT | Install percona-xtrabackup if needed
   apt:


### PR DESCRIPTION
 Warning:
```
TASK [HanXHX.mysql : APT | Install few MariaDB related tools] ******************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `pkg: {{ item }}`, please use `pkg: '{{ mariadb_tools }}'` and
remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

ansible 2.7.1
python 3.7.0