### PR TITLE
resolve ansible deprecation warnings

### DIFF
--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -2,7 +2,7 @@
 
 - name: INCLUDE | Setup Percona repository
   import_tasks: 'percona/apt.yml'
-  when: mariadb_use_percona_apt
+  when: mariadb_use_percona_apt | bool
 
 - name: INCLUDE | Setup MariaDB repository
   import_tasks: 'mariadb/upstream.yml'
@@ -19,4 +19,4 @@
 - name: APT | Install percona-xtrabackup if needed
   apt:
     pkg: "{{ mariadb_xtrabackup_package }}"
-  when: mariadb_install_xtrabackup_package
+  when: mariadb_install_xtrabackup_package | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,4 +77,4 @@
   template:
     src: "etc/logrotate.d/mysql-server.j2"
     dest: "/etc/logrotate.d/mysql-server"
-  when: mariadb_manage_logrotate
+  when: mariadb_manage_logrotate | bool


### PR DESCRIPTION
Ansible version 2.8.0 yields these type of deprecation warnings:
```
TASK [HanXHX.mysql : APT_KEY | Install Percona key] ****************************
[DEPRECATION WARNING]: evaluating mariadb_use_percona_apt as a bare variable,
this behaviour will go away and you might need to add |bool to the expression
in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This
feature will be removed in version 2.12. Deprecation warnings can be disabled
by setting deprecation_warnings=False in ansible.cfg.
```