### PR TITLE
Rolling reboot for Galera PC compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 env:
-  - PLATFORM='docker-buster-default-master'     ANSIBLE_VERSION='ansible>=2.8,<2.9'
-  - PLATFORM='docker-buster-upstream-master'    ANSIBLE_VERSION='ansible>=2.8,<2.9'
-  - PLATFORM='docker-buster-default-galera-1'   ANSIBLE_VERSION='ansible>=2.8,<2.9'
-  - PLATFORM='docker-buster-upstream-galera-1'  ANSIBLE_VERSION='ansible>=2.8,<2.9'
   - PLATFORM='docker-buster-default-master'     ANSIBLE_VERSION='ansible>=2.9,<2.10'
   - PLATFORM='docker-buster-upstream-master'    ANSIBLE_VERSION='ansible>=2.9,<2.10'
   - PLATFORM='docker-buster-default-galera-1'   ANSIBLE_VERSION='ansible>=2.9,<2.10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ services:
   - docker
 
 before_install:
-  - wget https://releases.hashicorp.com/vagrant/2.0.1/vagrant_2.0.1_x86_64.deb
-  - sudo dpkg -i vagrant_2.0.1_x86_64.deb
+  - wget https://releases.hashicorp.com/vagrant/2.1.1/vagrant_2.1.1_x86_64.deb
+  - sudo dpkg -i vagrant_2.1.1_x86_64.deb
   - vagrant plugin install vagrant-hostmanager
 
 install:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Notes
 Requirements
 ------------
 
-Ansible 2.8+
+Ansible 2.9+
 
 Role Variables
 --------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install and configure MariaDB (and Galera Cluster) on Debian
   company:
   license: GPLv2
-  min_ansible_version: 2.8
+  min_ansible_version: 2.9
   platforms:
   - name: Debian
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,8 @@
     - etc/mysql/mariadb.conf.d/50-server.cnf.j2
   register: config
 
-- name: SERVICE | Restart now (prevent bugs)
+- name: SERVICE | Restart Mariadb now one at a time (prevent bugs)
+  throttle: 1
   service:
     name: mysql
     state: restarted


### PR DESCRIPTION
When configuring a Galera cluster, we need to do a rolling reboot of all cluster members (instead of rebooting all node the same time) in order to preserve the Galera Primary Component up.