### PR TITLE
Fix Galera bootstrap issues

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -122,6 +122,8 @@ mariadb_upstream_version: '10.6'
 # -------------------------------------
 # Galera
 # -------------------------------------
+mariadb_galera_sst_user: galera
+mariadb_galera_sst_password: galera
 mariadb_galera_resetup: false
 mariadb_wsrep_node_address: false    # Set primary node IP
 mariadb_galera_members: []

--- a/tasks/galera/bootstrap.yml
+++ b/tasks/galera/bootstrap.yml
@@ -37,6 +37,9 @@
         priv: "*.*:RELOAD,LOCK TABLES,REPLICATION CLIENT,PROCESS"
         host: localhost
         state: present
+        check_implicit_admin: yes
+        login_user: root
+        login_password: "{{ mariadb_root_password | default(omit) }}"
       no_log: "{{ not mariadb_debug_role }}"
       when: mariadb_galera_sst_user != ''
 

--- a/tasks/galera/bootstrap.yml
+++ b/tasks/galera/bootstrap.yml
@@ -30,6 +30,16 @@
       register: bootstrap_run
       when: ansible_service_mgr != 'systemd'
 
+    - name: MYSQL_USER | Manage SST user...
+      community.mysql.mysql_user:
+        name: "{{ mariadb_galera_sst_user }}"
+        password: "{{ mariadb_galera_sst_password }}"
+        priv: "*.*:RELOAD,LOCK TABLES,REPLICATION CLIENT,PROCESS"
+        host: localhost
+        state: present
+      no_log: "{{ not mariadb_debug_role }}"
+      when: mariadb_galera_sst_user != ''
+
   when: not s.stat.exists or mariadb_galera_resetup
 
 - name: COMMAND | Create Bootstrap mark

--- a/tasks/galera/nodes.yml
+++ b/tasks/galera/nodes.yml
@@ -33,3 +33,10 @@
       state: started
 
   when: debiancnf.stdout != ondc.stdout
+
+- name: SERVICE | Restart MariaDB if needed
+  ansible.builtin.service:
+    name: "{{ mariadb_service_name }}"
+    state: restarted
+  when:
+    galeraconfig and bootstrap_run is defined and bootstrap_run['changed']

--- a/tasks/galera/nodes.yml
+++ b/tasks/galera/nodes.yml
@@ -1,4 +1,12 @@
 ---
+- name: SET_FACT | Prepare mark var
+  ansible.builtin.set_fact:
+    __mark: "{{ mariadb_datadir }}/.ansible_galera_boostrap"
+
+- name: STAT | Bootstrap mark
+  ansible.builtin.stat:
+    path: "{{ __mark }}"
+  register: s
 
 - name: COMMAND | GET debian.cnf from primary node
   ansible.builtin.command: cat /etc/mysql/debian.cnf
@@ -38,5 +46,10 @@
   ansible.builtin.service:
     name: "{{ mariadb_service_name }}"
     state: restarted
-  when:
-    galeraconfig and bootstrap_run is defined and bootstrap_run['changed']
+  throttle: 1
+  when: not s.stat.exists or mariadb_galera_resetup
+
+- name: COMMAND | Create Bootstrap mark
+  ansible.builtin.command: "touch {{ __mark }}"
+  args:
+    creates: "{{ __mark }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,9 @@
     name: "{{ item }}"
     state: present
     login_unix_socket: "{{ mariadb_socket }}"
+    check_implicit_admin: yes
+    login_user: root
+    login_password: "{{ mariadb_root_password | default(omit) }}"
   loop: "{{ mariadb_databases }}"
   when: not mariadb_use_galera or inventory_hostname == mariadb_galera_primary_node
 
@@ -77,6 +80,9 @@
     host_all: "{{ item.host_all | default(omit) }}"
     state: present
     login_unix_socket: "{{ mariadb_socket }}"
+    check_implicit_admin: yes
+    login_user: root
+    login_password: "{{ mariadb_root_password | default(omit) }}"
   loop: "{{ mariadb_users }}"
   no_log: "{{ not mariadb_debug_role }}"
   when: not mariadb_use_galera or inventory_hostname == mariadb_galera_primary_node

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,6 +66,7 @@
     state: present
     login_unix_socket: "{{ mariadb_socket }}"
   loop: "{{ mariadb_databases }}"
+  when: not mariadb_use_galera or inventory_hostname == mariadb_galera_primary_node
 
 - name: MYSQL_USER | Manages users...
   community.mysql.mysql_user:
@@ -78,3 +79,4 @@
     login_unix_socket: "{{ mariadb_socket }}"
   loop: "{{ mariadb_users }}"
   no_log: "{{ not mariadb_debug_role }}"
+  when: not mariadb_use_galera or inventory_hostname == mariadb_galera_primary_node

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -6,6 +6,9 @@
     host: "{{ item }}"
     state: absent
     login_unix_socket: "{{ mariadb_socket }}"
+    check_implicit_admin: yes
+    login_user: root
+    login_password: "{{ mariadb_root_password | default(omit) }}"
   loop:
     - "{{ ansible_hostname }}"
     - 127.0.0.1
@@ -17,3 +20,6 @@
     name: test
     state: absent
     login_unix_socket: "{{ mariadb_socket }}"
+    check_implicit_admin: yes
+    login_user: root
+    login_password: "{{ mariadb_root_password | default(omit) }}"


### PR DESCRIPTION
This fixes a few issues I had when bootstrapping a new Galera cluster.

1. A race condition exists when managing the users and database on all nodes. This change restricts these actions to the primary node.
2. I was unable to perform IST without first configuring SST authentication.
3. MariaDB is not restarted on the second and third nodes after configuring Galera.